### PR TITLE
There is a typo in definition of macro for Linkedin-Symbol

### DIFF
--- a/komacv.cls
+++ b/komacv.cls
@@ -379,7 +379,7 @@ setkeys=\kvsetkeys%
 \renewcommand*\@facebooksymbol{\facebooksymbol}
 }
   \ifdefempty{\linkedinsymbol}{}{%
-\renewcommand*\@linkedinesymbol{\linkedinsymbol}
+\renewcommand*\@linkedinsymbol{\linkedinsymbol}
 }
   \ifdefempty{\fsymbol}{}{%
 \renewcommand*\@fsymbol{\fsymbol}

--- a/komacv.dtx
+++ b/komacv.dtx
@@ -1099,7 +1099,7 @@ setkeys=\kvsetkeys%
 \renewcommand*\@facebooksymbol{\facebooksymbol}
 }
   \ifdefempty{\linkedinsymbol}{}{%
-\renewcommand*\@linkedinesymbol{\linkedinsymbol}
+\renewcommand*\@linkedinsymbol{\linkedinsymbol}
 }
   \ifdefempty{\fsymbol}{}{%
 \renewcommand*\@fsymbol{\fsymbol}


### PR DESCRIPTION
There is a typo at komacv.dtx:1102, where you find a spurious ”e“ in the internal macro's name:
`\@linkedinsymbol` is misspelled `\@linkedinesymbol`.